### PR TITLE
feat: Migrate to tag-based deployment

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -2,7 +2,8 @@ name: Build & Push Docker Image
 
 on:
   push:
-    branches: ["main"]
+    tags:
+      - 'v*.*.*'
 
 jobs:
   build:
@@ -11,6 +12,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Extract tag name
+        id: extract_tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Extracted tag: ${TAG}"
+
+          # Validate semantic version format (v#.#.#)
+          if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Tag ${TAG} does not match semantic versioning pattern v*.*.*"
+            exit 1
+          fi
 
       - name: "Create env file"
         run: |
@@ -38,7 +52,7 @@ jobs:
         with:
           context: app
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/horpakjs:v1.${{ github.run_number }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/horpakjs:${{ steps.extract_tag.outputs.tag }}
 
       - name: "Delete env file"
         run: |
@@ -46,10 +60,18 @@ jobs:
 
       - name: "Trigger manifest repo"
         run: |
-          curl -L \
+          RESPONSE=$(curl -L -w "%{http_code}" -o /tmp/response.json \
               -X POST \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{secrets.GIT_TOKEN}}"\
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/hongjs/horpak-nextjs-manifest/actions/workflows/pipeline.yml/dispatches \
-              -d '{"ref":"main", "inputs":{"DOCKER_TAG":"v1.${{ github.run_number }}"}}'
+              -d '{"ref":"main", "inputs":{"DOCKER_TAG":"${{ steps.extract_tag.outputs.tag }}"}}')
+
+          if [ "$RESPONSE" -eq 204 ]; then
+            echo "Successfully triggered manifest repo update for tag ${{ steps.extract_tag.outputs.tag }}"
+          else
+            echo "Failed to trigger manifest repo. HTTP status: $RESPONSE"
+            cat /tmp/response.json
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ serviceAccountKey.json
 app/.next/
 app/config/dev.ts
 
+.env

--- a/README.md
+++ b/README.md
@@ -282,6 +282,68 @@ docker build -t horpak-nextjs .
 docker-compose up
 ```
 
+## Deployment
+
+This project uses semantic versioning for automated deployments to Kubernetes via GitHub Actions.
+
+### Creating a Release
+
+Deployments are triggered by pushing semantic version tags to the repository:
+
+1. Ensure all changes are merged to the `main` branch:
+```bash
+git checkout main
+git pull origin main
+```
+
+2. Create and push a semantic version tag:
+```bash
+git tag v1.0.1
+git push origin v1.0.1
+```
+
+3. Monitor the deployment:
+   - **GitHub Actions**: https://github.com/hongjs/horpak-nextjs/actions
+   - **Docker Hub**: https://hub.docker.com/r/hongjsx/horpakjs/tags
+   - **Kubernetes**: `kubectl get pods -n horpakjs`
+
+### Tag Format Requirements
+
+Tags must follow semantic versioning with the pattern `v*.*.*`:
+
+- ✅ Valid: `v1.0.0`, `v2.5.3`, `v10.20.30`
+- ❌ Invalid: `v1`, `v1.0`, `latest`, `1.0.0` (missing 'v')
+
+The deployment workflow validates tag format and will fail if the tag doesn't match the required pattern.
+
+### Versioning Guide
+
+- **Patch version (v1.0.X)**: Bug fixes, security patches, minor improvements
+- **Minor version (v1.X.0)**: New features, backwards-compatible changes
+- **Major version (vX.0.0)**: Breaking changes, major refactoring
+
+### Deployment Process
+
+When a tag is pushed:
+1. GitHub Actions validates the tag format
+2. Builds a Docker image with the tag version
+3. Pushes the image to Docker Hub
+4. Triggers the manifest repository to update Kubernetes deployments
+5. Kubernetes deploys the new version with auto-scaling
+
+### Rollback
+
+If a deployment needs to be rolled back:
+
+```bash
+# Rollback to previous deployment
+kubectl rollout undo deployment/horpakjs-deployment -n horpakjs
+
+# Or deploy a specific version
+kubectl set image deployment/horpakjs-deployment \
+  horpakjs=hongjsx/horpakjs:v1.0.0 -n horpakjs
+```
+
 ## Contributing
 
 1. Create a feature branch from `main`


### PR DESCRIPTION
## Summary
  Migrates deployment workflow from main branch pushes to semantic version tag-based deployments.

  ## Changes
  - Replace main branch trigger with tag trigger (v*.*.*)
  - Add tag extraction and validation
  - Use git tag directly as Docker image tag
  - Update manifest repository integration
  - Add comprehensive deployment documentation

  ## Breaking Changes
  ⚠️ After merge, deployments will ONLY trigger on semantic version tags, not main branch pushes.

  ## Testing Plan
  1. Merge to main
  2. Create tag: `git tag v1.0.0 && git push origin v1.0.0`
  3. Verify GitHub Actions, Docker Hub, and Kubernetes deployment